### PR TITLE
Fixing a bug

### DIFF
--- a/lib/rabbitr.js
+++ b/lib/rabbitr.js
@@ -547,7 +547,7 @@ Rabbitr.prototype.rpcListener = function rpcListener(topic, executor, alreadyInQ
     
     var rpcQueue = self._rpcQueueName(topic);  
 
-    self.subscribe(rpcQueue, {});
+    self.subscribe(rpcQueue, function() { });
     self.bindExchangeToQueue(rpcQueue, rpcQueue, function() { });
     
     debug('has rpcListener for', topic);


### PR DESCRIPTION
In #rpcListener, #subscribe is called with an empty object instead of an empty function.